### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,21 +1,21 @@
 rms2dfinder
 ===============
-.. image:: https://pypip.in/py_versions/rms2dfinder/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/rms2dfinder.svg
     :target: https://pypi.python.org/pypi/rms2dfinder/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/status/rms2dfinder/badge.svg
+.. image:: https://img.shields.io/pypi/status/rms2dfinder.svg
     :target: https://pypi.python.org/pypi/rms2dfinder/
     :alt: Development Status
-.. image:: https://pypip.in/d/rms2dfinder/badge.png
+.. image:: https://img.shields.io/pypi/dm/rms2dfinder.svg
     :target: https://pypi.python.org/pypi/rms2dfinder/
     :alt: Downloads
 
-.. image:: https://pypip.in/v/rms2dfinder/badge.png
+.. image:: https://img.shields.io/pypi/v/rms2dfinder.svg
     :target: https://pypi.python.org/pypi/rms2dfinder/
     :alt: Latest version
 
-.. image:: https://pypip.in/wheel/rms2dfinder/badge.png
+.. image:: https://img.shields.io/pypi/wheel/rms2dfinder.svg
     :target: https://pypi.python.org/pypi/rms2dfinder/
     :alt: Wheel Status
 
@@ -23,7 +23,7 @@ rms2dfinder
     :target: https://pypi.python.org/pypi/rms2dfinder/
     :alt: Egg Status
 
-.. image:: https://pypip.in/license/rms2dfinder/badge.png
+.. image:: https://img.shields.io/pypi/l/rms2dfinder.svg
     :target: https://pypi.python.org/pypi/rms2dfinder/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20rms2dfinder))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `rms2dfinder`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.